### PR TITLE
Use retainedFileCountLimit and CompressionLevel.NoCompression

### DIFF
--- a/src/Serilog.Sinks.File.Archive/ArchiveHooks.cs
+++ b/src/Serilog.Sinks.File.Archive/ArchiveHooks.cs
@@ -36,12 +36,25 @@ namespace Serilog.Sinks.File.Archive
             this.targetDirectory = targetDirectory;
         }
 
+        /// <summary>
+        /// Create a new ArchiveHooks, which will archive completed log files before they are deleted by Serilog's retention mechanism
+        /// </summary>
+        /// <param name="retainedFileCountLimit">
+        /// Limit of Archived files.
+        /// <param name="compressionLevel">
+        /// Level of GZIP compression to use. Use CompressionLevel.NoCompression if no compression is required
+        /// </param>
+        /// <param name="targetDirectory">
+        /// Directory in which to archive files to. Use null if compressed, archived files should remain in the same folder
+        /// </param>
         public ArchiveHooks(int retainedFileCountLimit, CompressionLevel compressionLevel = CompressionLevel.Fastest, string targetDirectory = null)
         {
             if (retainedFileCountLimit <= 0)
                 throw new ArgumentException($"{nameof(retainedFileCountLimit)} must be greater than zero", nameof(retainedFileCountLimit));
             if (targetDirectory is not null && TokenExpander.IsTokenised(targetDirectory))
                 throw new ArgumentException($"{nameof(targetDirectory)} must not be tokenised when using {nameof(retainedFileCountLimit)}", nameof(targetDirectory));
+            if (compressionLevel == CompressionLevel.NoCompression && targetDirectory == null)
+                throw new ArgumentException($"Either {nameof(compressionLevel)} or {nameof(targetDirectory)} must be set");
 
             this.compressionLevel = compressionLevel;
             this.retainedFileCountLimit = retainedFileCountLimit;

--- a/src/Serilog.Sinks.File.Archive/ArchiveHooks.cs
+++ b/src/Serilog.Sinks.File.Archive/ArchiveHooks.cs
@@ -42,8 +42,6 @@ namespace Serilog.Sinks.File.Archive
                 throw new ArgumentException($"{nameof(retainedFileCountLimit)} must be greater than zero", nameof(retainedFileCountLimit));
             if (targetDirectory is not null && TokenExpander.IsTokenised(targetDirectory))
                 throw new ArgumentException($"{nameof(targetDirectory)} must not be tokenised when using {nameof(retainedFileCountLimit)}", nameof(targetDirectory));
-            if (compressionLevel == CompressionLevel.NoCompression)
-                throw new ArgumentException($"{nameof(compressionLevel)} must not be 'NoCompression' when using {nameof(retainedFileCountLimit)}", nameof(compressionLevel));
 
             this.compressionLevel = compressionLevel;
             this.retainedFileCountLimit = retainedFileCountLimit;


### PR DESCRIPTION
Removed the `throw new ArgumentException` to have the possibility to use `retainedFileCountLimit` and `CompressionLevel.NoCompression` 
Linked to issue #16 